### PR TITLE
[feat] add focus style props for non DOM renderers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ typings/
 # next.js build output
 .next
 
+# filesystem meta files
+.DS_Store
+
 dist
 lib
 es

--- a/babel.config.js
+++ b/babel.config.js
@@ -27,6 +27,7 @@ module.exports = api => {
       '@babel/plugin-proposal-object-rest-spread',
       '@babel/plugin-transform-destructuring',
       '@babel/plugin-proposal-nullish-coalescing-operator',
+      "@babel/plugin-proposal-optional-chaining"
     ],
     presets: [
       ['@babel/preset-env', config[configKey]],

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/core": "^7.11.1",
     "@babel/plugin-external-helpers": "^7.10.4",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+    "@babel/plugin-proposal-optional-chaining": "7.12.17",
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -77,6 +77,12 @@ export function FocusNode(
     disabledClass = 'focusDisabled',
     activeClass = 'isActive',
 
+    style = {},
+    focusedStyle = {},
+    focusedLeafStyle = {},
+    disabledStyle = {},
+    activeStyle = {},
+
     onKey,
     onArrow,
     onLeft,
@@ -314,6 +320,14 @@ export function FocusNode(
       : ''
   } ${node.active ? activeClass : ''}`;
 
+  const computedStyle = {
+    ...style,
+    ...(node.isFocused ? focusedStyle : {}),
+    ...(node.isFocusedLeaf ? focusedLeafStyle : {}),
+    ...(node.disabled ? disabledStyle : {}),
+    ...(node.active ? activeStyle : {}),
+  };
+
   return (
     <FocusContext.Context.Provider value={staticDefinitions.providerValue}>
       {createElement(elementType, {
@@ -321,6 +335,7 @@ export function FocusNode(
         ...computedProps,
         ref,
         className: classNameString,
+        style: computedStyle,
         children,
         onMouseOver(e: any) {
           // We only set focus via mouse to the leaf nodes that aren't disabled

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -322,10 +322,10 @@ export function FocusNode(
 
   const computedStyle = {
     ...style,
-    ...(node.isFocused ? focusedStyle : {}),
-    ...(node.isFocusedLeaf ? focusedLeafStyle : {}),
-    ...(node.disabled ? disabledStyle : {}),
-    ...(node.active ? activeStyle : {}),
+    ...(node.isFocused && focusedStyle),
+    ...(node.isFocusedLeaf && focusedLeafStyle),
+    ...(node.disabled && disabledStyle),
+    ...(node.active && activeStyle),
   };
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,6 +244,12 @@ export interface FocusNodeProps extends FocusNodeEvents {
   focusedLeafClass?: string;
   disabledClass?: string;
   activeClass?: string;
+
+  style?: object;
+  focusedStyle?: object;
+  focusedLeafStyle?: object;
+  disabledStyle?: object;
+  activeStyle?: object;
 }
 
 export interface GridStyle {

--- a/src/utils/warning.test.ts
+++ b/src/utils/warning.test.ts
@@ -8,8 +8,7 @@ beforeEach(() => {
 describe('warning()', () => {
   it('calls console.error', () => {
     expect.assertions(2);
-
-    const consoleErrorSpy = jest.spyOn(console, 'error');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => ({error: () => {}}));
 
     const mockErrorMessage = 'Cake wasn\'t good!';
     const mockErrorCode = 'BAD_CAKE';
@@ -21,7 +20,7 @@ describe('warning()', () => {
 
   it('does not call console.error again if warning() was called with the same code', () => {
     expect.assertions(2);
-    const consoleErrorSpy = jest.spyOn(console, 'error');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => ({error: () => {}}));
 
     const mockErrorMessage = 'Who ate all the cake?';
     const mockErrorCode = 'NEED_MORE_CAKE';
@@ -38,7 +37,7 @@ describe('warning()', () => {
 describe('resetCodeCache()', () => {
   it('clears the codeCache, allowing repeat calls of the same code', () => {
     expect.assertions(2);
-    const consoleErrorSpy = jest.spyOn(console, 'error');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => ({error: () => {}}));
 
     const mockErrorMessage = 'Where is my slice of cake?';
     const mockErrorCode = 'USER_MISSING_CAKE';

--- a/src/utils/warning.test.ts
+++ b/src/utils/warning.test.ts
@@ -1,0 +1,55 @@
+import warning, {resetCodeCache} from "./warning";
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.resetAllMocks();
+})
+
+describe('warning()', () => {
+  it('calls console.error', () => {
+    expect.assertions(2);
+
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    const mockErrorMessage = 'Cake wasn\'t good!';
+    const mockErrorCode = 'BAD_CAKE';
+    warning(mockErrorMessage, mockErrorCode);
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(mockErrorMessage);
+  });
+
+  it('does not call console.error again if warning() was called with the same code', () => {
+    expect.assertions(2);
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    const mockErrorMessage = 'Who ate all the cake?';
+    const mockErrorCode = 'NEED_MORE_CAKE';
+
+    warning(mockErrorMessage, mockErrorCode);
+
+    warning(mockErrorMessage, mockErrorCode);
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(mockErrorMessage);
+  });
+})
+
+describe('resetCodeCache()', () => {
+  it('clears the codeCache, allowing repeat calls of the same code', () => {
+    expect.assertions(2);
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    const mockErrorMessage = 'Where is my slice of cake?';
+    const mockErrorCode = 'USER_MISSING_CAKE';
+
+    warning(mockErrorMessage, mockErrorCode);
+
+    resetCodeCache();
+
+    warning(mockErrorMessage, mockErrorCode);
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(mockErrorMessage);
+  })
+})


### PR DESCRIPTION
This PR:

- adds `focusedStyle`, `focusedLeafStyle`, `disabledStyle` and `activeStyle` props. These props merge a given style object to the existing `style` object prop for the inner component.
- adds the optional chaining babel plugin(https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining). I needed this while importing the lib locally, via `file:../etc`. Running `npm run build` and then importing your forked lib via `file:../path/to/lrud` wasn't recognising the optional chaining here, https://github.com/jamesplease/lrud/blob/master/src/utils/create-node.ts#L77 This is important as with this fix I can resume creating replicas of the `/examples` folder, using `revas` instead
- tested on the [`revas`](https://github.com/pinqy520/revas) renderer, which uses similar styling idioms to React Native

### Example

```javascript

const styles = {
  view: {
    borderWidth: 1,
    borderColor: 'transparent',
    borderStyle: 'solid'
  },
  focused: {
    borderColor: 'magenta'
  }
}

<FocusNode elementType={View} style={styles.view} focusedStyle={styles.focused}/>
```

### Notes

My motivation for writing this was to use the `lrud` lib with a non ReactDom renderer, in this case `revas`.

### Issues

- I had difficulties writing a test for the `<FocusNode/>` component, as to do so would require `react` and `react-dom`. Adding those, even if only for a test, seems to include them in the bundle deps and this then causes conflicts with react projects wanting to use `lrud`. I _think_ the issue is related to the output of the build including `*.test.ts{x}` files as well, but am not sure, and also could not work out how to make babel not include such files when building.
- with the above in mind, I buffed up the coverage for the `warning()` util, which gets a green tick on the pipeline, but is perhaps against the intent of the coverage. Certainly feels like it's gaming it a bit.
- I've copied some of the examples, modifying them for the alternate renderer, and so far have `basic`, `grid`, `trap` working much like the `react-dom` equivalents. I will push them to my github repo soon.