### PR TITLE
Improved pointer event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,15 +418,17 @@ An object that represents the store that contains all of the state related to wh
 Typically, you should not need to interact with this object directly, but it is made available to you
 for advanced use cases that you may have.
 
-| Property       | Type     | Description                                                            |
-| -------------- | -------- | ---------------------------------------------------------------------- |
-| `getState`     | function | Returns the current [FocusState](#focusstate)                          |
-| `createNodes`  | function | Creates one or more focus nodes in the tree.                           |
-| `deleteNode`   | function | Deletes a focus node from the tree.                                    |
-| `setFocus`     | function | Imperatively assign focus to a particular focus node.                  |
-| `updateNode`   | function | Update an existing node. Used to, for example, set a node as disabled. |
-| `handleArrow`  | function | Call this to navigate based on an arrow key press.                     |
-| `handleSelect` | function | Call this to cause the focus tree to respond to a "select" key press.  |
+| Property                 | Type     | Description                                                            |
+| ------------------------ | -------- | ---------------------------------------------------------------------- |
+| `getState`               | function | Returns the current [FocusState](#focusstate)                          |
+| `createNodes`            | function | Creates one or more focus nodes in the tree.                           |
+| `deleteNode`             | function | Deletes a focus node from the tree.                                    |
+| `setFocus`               | function | Imperatively assign focus to a particular focus node.                  |
+| `updateNode`             | function | Update an existing node. Used to, for example, set a node as disabled. |
+| `handleArrow`            | function | Call this to navigate based on an arrow key press.                     |
+| `handleSelect`           | function | Call this to cause the focus tree to respond to a "select" key press.  |
+| `configurePointerEvents` | function | Enable or disable pointer events. Receives one argument, a `boolean`.  | 
+| `destroy`                | function | Call when disposing of the store. Cleans up event listeners.           |
 
 ### `FocusState`
 
@@ -434,13 +436,16 @@ for advanced use cases that you may have.
 
 An object representing the state of the focus in the app.
 
-| Property                 | Type             | Description                                                          |
-| ------------------------ | ---------------- | -------------------------------------------------------------------- |
-| `focusedNodeId`          | string           | The ID of the leaf node in the focus hierarchy.                      |
-| `focusHierarchy`         | Array            | An array of node IDs representing the focus hierarchy.               |
-| `activeNodeId`           | string \| `null` | The ID of the active node, if there is one.                          |
-| `nodes`                  | Object           | A mapping of all of the focus nodes that exist.                      |
-| `_updatingFocusIsLocked` | boolean          | A boolean used internally for managing the creation of nested nodes. |
+| Property                   | Type             | Description                                                             |
+| -------------------------- | ---------------- | ----------------------------------------------------------------------- |
+| `focusedNodeId`            | string           | The ID of the leaf node in the focus hierarchy.                         |
+| `focusHierarchy`           | Array            | An array of node IDs representing the focus hierarchy.                  |
+| `activeNodeId`             | string \| `null` | The ID of the active node, if there is one.                             |
+| `nodes`                    | Object           | A mapping of all of the focus nodes that exist.                         |
+| `interactionMode`          | string           | The active interaction mode of the app. Either `"lrud"` or `"pointer"`. |
+| `_hasPointerEventsEnabled` | boolean          | A boolean used internally for managing the creation of nested nodes.    |
+| `_hasPointerEventsEnabled` | boolean          | Whether or not pointer events are currently enabled.                    |
+| `_updatingFocusIsLocked`   | boolean          | A boolean used internally for managing the creation of nested nodes.    |
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@please/lrud",
-  "version": "0.0.12",
+  "version": "0.0.13-beta.1",
   "description": "A React library for managing focus in TV apps.",
   "main": "es/index.js",
   "module": "es/index.js",

--- a/src/focus-context.tsx
+++ b/src/focus-context.tsx
@@ -6,14 +6,16 @@ import warning from './utils/warning';
 
 const FocusContext = React.createContext<null | ProviderValue>(null);
 
-function FocusProviderWrapper({
+function FocusRoot({
   orientation,
   wrapping,
   children,
+  pointerEvents,
 }: {
   children?: React.ReactNode;
   orientation?: Orientation;
   wrapping?: boolean;
+  pointerEvents?: boolean;
 }) {
   const rootElRef = useRef(null);
   const [providerValue] = useState<ProviderValue>(() => {
@@ -33,6 +35,7 @@ function FocusProviderWrapper({
     const store = createFocusStore({
       orientation,
       wrapping,
+      pointerEvents,
     });
 
     return {
@@ -66,5 +69,5 @@ function FocusProviderWrapper({
 
 export default {
   Context: FocusContext,
-  FocusRoot: FocusProviderWrapper,
+  FocusRoot,
 };

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -259,11 +259,6 @@ export function FocusNode(
   });
 
   const { store } = contextValue as ProviderValue;
-  const storeRef = useRef(store);
-
-  useEffect(() => {
-    storeRef.current = store;
-  }, [store]);
 
   const [node, setNode] = useState<FocusNodeType>(() => {
     return staticDefinitions.initialNode;
@@ -336,7 +331,7 @@ export function FocusNode(
         children,
         onMouseOver(e: any) {
           // We only set focus via mouse to the leaf nodes that aren't disabled
-          const focusState = storeRef.current.getState();
+          const focusState = staticDefinitions.providerValue.store.getState();
 
           if (
             nodeRef.current &&
@@ -365,7 +360,7 @@ export function FocusNode(
             return;
           }
 
-          const focusState = storeRef.current.getState();
+          const focusState = staticDefinitions.providerValue.store.getState();
           if (!focusState._hasPointerEventsEnabled) {
             return;
           }

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -259,6 +259,11 @@ export function FocusNode(
   });
 
   const { store } = contextValue as ProviderValue;
+  const storeRef = useRef(store);
+
+  useEffect(() => {
+    storeRef.current = store;
+  }, [store]);
 
   const [node, setNode] = useState<FocusNodeType>(() => {
     return staticDefinitions.initialNode;
@@ -331,10 +336,14 @@ export function FocusNode(
         children,
         onMouseOver(e: any) {
           // We only set focus via mouse to the leaf nodes that aren't disabled
+          const focusState = storeRef.current.getState();
+
           if (
             nodeRef.current &&
             nodeRef.current.children.length === 0 &&
-            !nodeRef.current.disabled
+            !nodeRef.current.disabled &&
+            focusState._hasPointerEventsEnabled &&
+            focusState.interactionMode === 'pointer'
           ) {
             staticDefinitions.providerValue.store.setFocus(nodeId);
           }
@@ -353,6 +362,11 @@ export function FocusNode(
           const isDisabled = nodeRef.current && nodeRef.current.disabled;
 
           if (!isLeaf || isDisabled) {
+            return;
+          }
+
+          const focusState = storeRef.current.getState();
+          if (!focusState._hasPointerEventsEnabled) {
             return;
           }
 

--- a/src/focus-store.ts
+++ b/src/focus-store.ts
@@ -466,7 +466,6 @@ export default function createFocusStore({
     updateNode,
     handleArrow,
     handleSelect,
-    setInteractionMode,
     configurePointerEvents,
     destroy,
   };

--- a/src/focus-store.ts
+++ b/src/focus-store.ts
@@ -16,23 +16,32 @@ import {
   NodeUpdate,
   Listener,
   NodeDefinition,
+  InteractionMode,
 } from './types';
 
 interface CreateFocusStoreOptions {
   orientation?: Orientation;
   wrapping?: boolean;
   navigationStyle?: NavigationStyle;
+  pointerEvents?: boolean;
 }
 
 export default function createFocusStore({
   orientation = 'horizontal',
   wrapping = false,
+  pointerEvents = true,
 }: CreateFocusStoreOptions = {}): FocusStore {
   let currentState: FocusState = {
     focusedNodeId: 'root',
     activeNodeId: null,
     focusHierarchy: ['root'],
+
+    // TODO: should the interaction state values be moved out of the state and placed
+    // on the store directly?
+    interactionMode: 'lrud',
     _updatingFocusIsLocked: false,
+    _hasPointerEventsEnabled: pointerEvents,
+
     nodes: {
       root: {
         // Note: this a "fake" React ref in that React isn't ensuring
@@ -216,6 +225,19 @@ export default function createFocusStore({
     });
   }
 
+  function setInteractionMode(newMode: InteractionMode) {
+    if (newMode === currentState.interactionMode) {
+      return;
+    }
+
+    const newFocusState: FocusState = {
+      ...currentState,
+      interactionMode: newMode,
+    };
+
+    currentState = newFocusState;
+  }
+
   function updateNode(nodeId: Id, update: NodeUpdate) {
     const currentNode = currentState.nodes[nodeId];
 
@@ -322,6 +344,10 @@ export default function createFocusStore({
       return;
     }
 
+    if (newState.interactionMode !== 'lrud') {
+      newState.interactionMode = 'lrud';
+    }
+
     if (newState !== currentState) {
       currentState = newState;
       onUpdate();
@@ -376,6 +402,61 @@ export default function createFocusStore({
     onUpdate();
   }
 
+  // This boolean tracks whether or not we have registered our pointer listeners.
+  // This ensures that we never register those listeners more than once.
+  let isListeningToPointerEvents = false;
+
+  // This allows a user to dynamically enable/disable pointer events.
+  function configurePointerEvents(enablePointerEvents: boolean) {
+    const existingState = currentState;
+
+    currentState = {
+      ...existingState,
+      _hasPointerEventsEnabled: enablePointerEvents,
+    };
+
+    if (enablePointerEvents && !isListeningToPointerEvents) {
+      addPointerListeners();
+    }
+
+    if (!enablePointerEvents) {
+      removePointerListeners();
+    }
+  }
+
+  let handlingPointerEvent = false;
+  function onPointerEvent() {
+    if (handlingPointerEvent) {
+      return;
+    }
+
+    handlingPointerEvent = true;
+    requestAnimationFrame(() => {
+      setInteractionMode('pointer');
+      handlingPointerEvent = false;
+    });
+  }
+
+  function addPointerListeners() {
+    isListeningToPointerEvents = true;
+    window.addEventListener('mousemove', onPointerEvent);
+    window.addEventListener('mousedown', onPointerEvent);
+  }
+
+  function removePointerListeners() {
+    isListeningToPointerEvents = false;
+    window.removeEventListener('mousemove', onPointerEvent);
+    window.removeEventListener('mousedown', onPointerEvent);
+  }
+
+  function destroy() {
+    removePointerListeners();
+  }
+
+  if (pointerEvents) {
+    addPointerListeners();
+  }
+
   return {
     subscribe,
     getState,
@@ -385,5 +466,8 @@ export default function createFocusStore({
     updateNode,
     handleArrow,
     handleSelect,
+    setInteractionMode,
+    configurePointerEvents,
+    destroy,
   };
 }

--- a/src/focus-store.ts
+++ b/src/focus-store.ts
@@ -29,7 +29,7 @@ interface CreateFocusStoreOptions {
 export default function createFocusStore({
   orientation = 'horizontal',
   wrapping = false,
-  pointerEvents = true,
+  pointerEvents = false,
 }: CreateFocusStoreOptions = {}): FocusStore {
   let currentState: FocusState = {
     focusedNodeId: 'root',
@@ -39,9 +39,9 @@ export default function createFocusStore({
     // TODO: should the interaction state values be moved out of the state and placed
     // on the store directly?
     interactionMode: 'lrud',
-    _updatingFocusIsLocked: false,
     _hasPointerEventsEnabled: pointerEvents,
 
+    _updatingFocusIsLocked: false,
     nodes: {
       root: {
         // Note: this a "fake" React ref in that React isn't ensuring

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,12 +164,16 @@ export interface NodeMap {
   [key: string]: Node | undefined;
 }
 
+export type InteractionMode = 'lrud' | 'pointer';
+
 export interface FocusState {
   focusedNodeId: Id;
   activeNodeId: Id | null;
   focusHierarchy: Id[];
+  interactionMode: InteractionMode;
   nodes: NodeMap;
   _updatingFocusIsLocked: boolean;
+  _hasPointerEventsEnabled: boolean;
 }
 
 export interface NodeDefinition extends FocusNodeEvents {
@@ -214,6 +218,9 @@ export interface FocusStore {
   updateNode: UpdateNode;
   handleArrow: (arrow: Arrow) => void;
   handleSelect: (nodeId?: Id) => void;
+  setInteractionMode: (interactionMode: InteractionMode) => void;
+  configurePointerEvents: (enablePointerEvents: boolean) => void;
+  destroy: () => void;
 }
 
 export interface ProviderValue {

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,7 +218,6 @@ export interface FocusStore {
   updateNode: UpdateNode;
   handleArrow: (arrow: Arrow) => void;
   handleSelect: (nodeId?: Id) => void;
-  setInteractionMode: (interactionMode: InteractionMode) => void;
   configurePointerEvents: (enablePointerEvents: boolean) => void;
   destroy: () => void;
 }

--- a/src/update-focus/update-focus.ts
+++ b/src/update-focus/update-focus.ts
@@ -58,6 +58,8 @@ export default function updateFocus({
     focusHierarchy: newFocusHierarchy,
     focusedNodeId,
     activeNodeId: focusState.activeNodeId,
+    interactionMode: focusState.interactionMode,
+    _hasPointerEventsEnabled: focusState._hasPointerEventsEnabled,
   };
 
   emitFocusStateEvents({


### PR DESCRIPTION
Resolves #37 

---

This more closely matches the behavior of most TV interfaces by using interaction modes. If you press LRUD, then pointer events are "disabled," and the pointer no longer functions (it may even disappear). Then, if you move the cursor, the mode switches to pointer events.