### PR TITLE
Update tree update behavior

### DIFF
--- a/src/handle-arrow/determine-navigation-style/get-default-nav-target.ts
+++ b/src/handle-arrow/determine-navigation-style/get-default-nav-target.ts
@@ -1,4 +1,4 @@
-import nodeCanBeArrowed from './node-can-be-arrowed';
+import nodeCanReceiveIndirectFocus from '../../utils/node-can-receive-indirect-focus';
 import { FocusState, Node, Orientation, Direction, Id } from '../../types';
 
 export default function getDefaultNavTarget(
@@ -24,7 +24,7 @@ export default function getDefaultNavTarget(
       const parentsChildren = unfilteredChildren.filter((nodeId) => {
         const node = focusState.nodes[nodeId];
 
-        if (!nodeCanBeArrowed(focusState, node)) {
+        if (!nodeCanReceiveIndirectFocus(focusState, node)) {
           return false;
         }
 

--- a/src/tests/focus-trap.test.js
+++ b/src/tests/focus-trap.test.js
@@ -31,7 +31,7 @@ describe('Focus Traps', () => {
     expect(warning.mock.calls[0][1]).toEqual('RESTORE_TRAP_FOCUS_WITHOUT_TRAP');
   });
 
-  it.skip('does not focus on mount', () => {
+  it('does not focus on mount', () => {
     let focusStore;
 
     function TestComponent() {

--- a/src/tests/tree-updates.test.js
+++ b/src/tests/tree-updates.test.js
@@ -120,13 +120,13 @@ describe('Tree updates', () => {
     act(() => updateMountState(true));
 
     focusState = focusStore.getState();
-    expect(focusState.focusedNodeId).toEqual('nodeA-A');
-    expect(focusState.focusHierarchy).toEqual(['root', 'nodeA', 'nodeA-A']);
+    expect(focusState.focusedNodeId).toEqual('nodeA');
+    expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(4);
   });
 
-  it.skip('focus trap child', () => {
+  it('focus trap child', () => {
     let focusStore;
     let updateMountState;
 

--- a/src/utils/node-can-receive-indirect-focus.ts
+++ b/src/utils/node-can-receive-indirect-focus.ts
@@ -1,6 +1,16 @@
-import { FocusState, Node } from '../../types';
+import { FocusState, Node } from '../types';
 
-export default function nodeCanBeArrowed(focusState: FocusState, node?: Node) {
+// "Indirect focus" here means:
+// 1. receiving focus when a parent node receives focus, either through LRUD input or through an explicit call
+//    to `setFocus`
+// 2. receiving focus after being mounted
+//
+// This function ensures that things like disabled nodes don't receive focus when LRUD is input or when they mount.
+
+export default function nodeCanReceiveIndirectFocus(
+  focusState: FocusState,
+  node?: Node
+) {
   if (!node) {
     return false;
   }
@@ -21,7 +31,10 @@ export default function nodeCanBeArrowed(focusState: FocusState, node?: Node) {
       const childId = children[i];
       const childNode = focusState.nodes[childId];
 
-      const childCanReceiveFocus = nodeCanBeArrowed(focusState, childNode);
+      const childCanReceiveFocus = nodeCanReceiveIndirectFocus(
+        focusState,
+        childNode
+      );
 
       if (childCanReceiveFocus) {
         someChildIsEnabled = true;

--- a/src/utils/tree-navigation.ts
+++ b/src/utils/tree-navigation.ts
@@ -1,6 +1,6 @@
 import clamp from './clamp';
+import nodeCanReceiveIndirectFocus from './node-can-receive-indirect-focus';
 import { FocusState, Id, NodeHierarchy, Orientation } from '../types';
-import nodeCanBeArrowed from '../handle-arrow/determine-navigation-style/node-can-be-arrowed';
 
 interface GetParentsOptions {
   focusState: FocusState;
@@ -55,7 +55,7 @@ export function getChildren({
   const nodeChildren = node.children.filter((childId) => {
     const node = focusState.nodes[childId];
 
-    return nodeCanBeArrowed(focusState, node);
+    return nodeCanReceiveIndirectFocus(focusState, node);
   });
 
   let nextPreferredChildren: NodeHierarchy = [];

--- a/src/utils/tree-navigation.ts
+++ b/src/utils/tree-navigation.ts
@@ -1,5 +1,6 @@
 import clamp from './clamp';
 import { FocusState, Id, NodeHierarchy, Orientation } from '../types';
+import nodeCanBeArrowed from '../handle-arrow/determine-navigation-style/node-can-be-arrowed';
 
 interface GetParentsOptions {
   focusState: FocusState;
@@ -54,8 +55,7 @@ export function getChildren({
   const nodeChildren = node.children.filter((childId) => {
     const node = focusState.nodes[childId];
 
-    const isEnabled = node && !node.disabled && !node.isExiting;
-    return isEnabled;
+    return nodeCanBeArrowed(focusState, node);
   });
 
   let nextPreferredChildren: NodeHierarchy = [];


### PR DESCRIPTION
Resolves #55 

---

Disabled/isExiting/trap nodes all behave identically now: they cannot receive focus due to mounting or arrows. However, traps can still receive focus by directly calling `setFocus`.