### PR TITLE
feature: useFocusNode parameter focusId in now optional - default returns current focused leaf node

### DIFF
--- a/src/hooks/use-focus-node.test.js
+++ b/src/hooks/use-focus-node.test.js
@@ -95,4 +95,51 @@ describe('useFocusNode', () => {
 
     expect(focusNode).toEqual(null);
   });
+
+  it('returns the current focused leaf node', () => {
+    let setFocus;
+    let focusNode;
+    let focusStore;
+
+    function TestComponent() {
+      setFocus = useSetFocus();
+      focusNode = useFocusNode();
+      focusStore = useFocusStoreDangerously();
+
+      return (
+        <>
+          <FocusNode focusId="nodeA" data-testid="nodeA" />
+          <FocusNode focusId="nodeB" data-testid="nodeB" />
+        </>
+      );
+    }
+
+    render(
+      <FocusRoot>
+        <TestComponent />
+      </FocusRoot>
+    );
+
+    expect(focusNode).toEqual(
+      expect.objectContaining({
+        focusId: 'nodeA',
+        isFocused: true,
+        isFocusedLeaf: true,
+      })
+    );
+
+    expect(focusNode).toBe(focusStore.getState().nodes.nodeA);
+
+    act(() => setFocus('nodeB'));
+
+    expect(focusNode).toEqual(
+      expect.objectContaining({
+        focusId: 'nodeB',
+        isFocused: true,
+        isFocusedLeaf: true,
+      })
+    );
+
+    expect(focusNode).toBe(focusStore.getState().nodes.nodeB);
+  });
 });


### PR DESCRIPTION
Answers to #76 

Instead of creating `useFocusedNode`, i changed embedded the behavior for useFocusNode's parameter `focusId`
The current tests keeps on passing (i cannot test passing variable then not passing [and vice versa], but i think it should work), plus i added a simple test for this behavior


I know, it's opinionated but `useFocusedNode` seemed to me a 1:1 copy of `useFocusNode` without focusId...