### PR TITLE
Enforce structure tests

### DIFF
--- a/src/focus-node.test.js
+++ b/src/focus-node.test.js
@@ -23,6 +23,9 @@ describe('FocusNode', () => {
       render(<TestComponent />);
     }).toThrow();
 
+    // TODO: check what these calls are
+    expect(console.error).toHaveBeenCalledTimes(2);
+
     expect(warning).toHaveBeenCalledTimes(2);
     expect(warning.mock.calls[0][1]).toEqual('NO_FOCUS_PROVIDER_DETECTED');
     // Note: I'm not entirely sure why the warning is called twice in this test...but that's OK
@@ -54,6 +57,9 @@ describe('FocusNode', () => {
 
       const nodeA = screen.getByTestId('nodeA');
       expect(nodeA instanceof HTMLDivElement).toBe(true);
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
 
     it('can be customized', () => {
@@ -80,6 +86,9 @@ describe('FocusNode', () => {
 
       const nodeA = screen.getByTestId('nodeA');
       expect(nodeA instanceof HTMLSpanElement).toBe(true);
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -113,6 +122,9 @@ describe('FocusNode', () => {
 
       const nodeA = screen.getByTestId('nodeA');
       expect(nodeA).toHaveClass('focusedPls', 'focusedLeafPls');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
 
     it('disabled', () => {
@@ -144,6 +156,9 @@ describe('FocusNode', () => {
 
       const nodeA = screen.getByTestId('nodeA');
       expect(nodeA).toHaveClass('disabledPls');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -169,6 +184,9 @@ describe('FocusNode', () => {
       );
 
       expect(focusStore.getState().focusedNodeId).toBe('nodeA');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
 
     it('generates its own ID when one is not provided', () => {
@@ -194,6 +212,9 @@ describe('FocusNode', () => {
       expect(typeof focusStore.getState().focusedNodeId === 'string').toBe(
         true
       );
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
 
     it('warns if an invalid ID is passed, but still generates a valid one', () => {
@@ -222,6 +243,8 @@ describe('FocusNode', () => {
 
       expect(warning).toHaveBeenCalledTimes(1);
       expect(warning.mock.calls[0][1]).toEqual('INVALID_FOCUS_ID_PASSED');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('warns if the ID "root" is passed in, but still generates a valid one', () => {
@@ -252,6 +275,7 @@ describe('FocusNode', () => {
 
       expect(warning).toHaveBeenCalledTimes(1);
       expect(warning.mock.calls[0][1]).toEqual('ROOT_ID_WAS_PASSED');
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -290,9 +314,14 @@ describe('FocusNode', () => {
       let nodeA = screen.getByTestId('nodeA');
       expect(nodeA).toHaveClass('sandwiches');
 
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
       act(() => setFocus('nodeB'));
 
       expect(nodeA).toHaveClass('spaghetti');
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -322,6 +351,9 @@ describe('FocusNode', () => {
       expect(focusStore.getState().focusedNodeId).toBe('nodeA');
       let nodeA = screen.getByTestId('nodeA');
       expect(elRef.current).toBe(nodeA);
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/focus-root.test.js
+++ b/src/focus-root.test.js
@@ -44,12 +44,8 @@ describe('<FocusRoot/>', () => {
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(3);
 
-      fireEvent.keyDown(window, {
-        code: 'ArrowRight',
-        key: 'ArrowRight',
-      });
-
-      expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
 
       fireEvent.keyDown(window, {
         code: 'ArrowRight',
@@ -57,6 +53,19 @@ describe('<FocusRoot/>', () => {
       });
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
+      fireEvent.keyDown(window, {
+        code: 'ArrowRight',
+        key: 'ArrowRight',
+      });
+
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
 
     it('supports wrapping', () => {
@@ -97,6 +106,9 @@ describe('<FocusRoot/>', () => {
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(3);
 
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
       fireEvent.keyDown(window, {
         code: 'ArrowRight',
         key: 'ArrowRight',
@@ -104,12 +116,18 @@ describe('<FocusRoot/>', () => {
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
 
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
       fireEvent.keyDown(window, {
         code: 'ArrowRight',
         key: 'ArrowRight',
       });
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeA');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -152,12 +170,8 @@ describe('<FocusRoot/>', () => {
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(3);
 
-      fireEvent.keyDown(window, {
-        code: 'ArrowDown',
-        key: 'ArrowDown',
-      });
-
-      expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
 
       fireEvent.keyDown(window, {
         code: 'ArrowDown',
@@ -165,6 +179,19 @@ describe('<FocusRoot/>', () => {
       });
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
+      fireEvent.keyDown(window, {
+        code: 'ArrowDown',
+        key: 'ArrowDown',
+      });
+
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
 
     it('warns on invalid orientation values', () => {
@@ -184,6 +211,8 @@ describe('<FocusRoot/>', () => {
 
       expect(warning).toHaveBeenCalledTimes(1);
       expect(warning.mock.calls[0][1]).toEqual('INVALID_ROOT_ORIENTATION');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -226,6 +255,9 @@ describe('<FocusRoot/>', () => {
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(3);
 
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
       fireEvent.keyDown(window, {
         code: 'ArrowDown',
         key: 'ArrowDown',
@@ -233,12 +265,18 @@ describe('<FocusRoot/>', () => {
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
 
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
+
       fireEvent.keyDown(window, {
         code: 'ArrowDown',
         key: 'ArrowDown',
       });
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeA');
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(warning).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/hooks/use-active-node.test.js
+++ b/src/hooks/use-active-node.test.js
@@ -93,6 +93,7 @@ describe('useActiveNode', () => {
 
       focusState = focusStore.getState();
       expect(activeNode).toBe(focusState.nodes.nodeA);
+      expect(console.error).toHaveBeenCalledTimes(0);
 
       done();
     });

--- a/src/hooks/use-focus-events.test.js
+++ b/src/hooks/use-focus-events.test.js
@@ -72,6 +72,7 @@ describe('useFocusEvents', () => {
       expect(nodeAOnBlurred.mock.calls.length).toBe(1);
       expect(nodeBOnFocused.mock.calls.length).toBe(1);
       expect(nodeBOnBlurred.mock.calls.length).toBe(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -148,6 +149,7 @@ describe('useFocusEvents', () => {
       expect(nodeAOnEnabled.mock.calls.length).toBe(1);
       expect(nodeBOnDisabled.mock.calls.length).toBe(0);
       expect(nodeBOnEnabled.mock.calls.length).toBe(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('works when disabled on mount', () => {
@@ -222,6 +224,7 @@ describe('useFocusEvents', () => {
       expect(nodeAOnEnabled.mock.calls.length).toBe(1);
       expect(nodeBOnDisabled.mock.calls.length).toBe(0);
       expect(nodeBOnEnabled.mock.calls.length).toBe(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -318,6 +321,7 @@ describe('useFocusEvents', () => {
         expect(nodeBOnActive.mock.calls.length).toBe(1);
         expect(nodeBOnInactive.mock.calls.length).toBe(1);
 
+        expect(console.error).toHaveBeenCalledTimes(0);
         done();
       });
     });

--- a/src/hooks/use-focus-hierarchy.test.js
+++ b/src/hooks/use-focus-hierarchy.test.js
@@ -55,5 +55,6 @@ describe('useFocusHierarchy', () => {
     expect(focusHierarchy.map((node) => node.focusId)).toEqual(
       focusStore.getState().focusHierarchy
     );
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/hooks/use-focus-node.test.js
+++ b/src/hooks/use-focus-node.test.js
@@ -71,6 +71,7 @@ describe('useFocusNode', () => {
     );
 
     expect(focusNode).toBe(focusStore.getState().nodes.nodeA);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('returns null if the node does not exist', () => {
@@ -94,5 +95,6 @@ describe('useFocusNode', () => {
     );
 
     expect(focusNode).toEqual(null);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/hooks/use-leaf-focused-node.test.js
+++ b/src/hooks/use-leaf-focused-node.test.js
@@ -87,6 +87,7 @@ describe('useLeafFocusedNode', () => {
         isFocusedLeaf: true,
       })
     );
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('returns the root node if there are no focusable nodes (default focus state behavior)', () => {
@@ -114,5 +115,6 @@ describe('useLeafFocusedNode', () => {
     );
 
     expect(focusNode).toEqual(focusRootNode);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/hooks/use-set-focus.test.js
+++ b/src/hooks/use-set-focus.test.js
@@ -72,6 +72,7 @@ describe('useSetFocus', () => {
     nodeB = screen.getByTestId('nodeB');
     expect(nodeB).not.toHaveClass('isFocused');
     expect(nodeB).not.toHaveClass('isFocusedLeaf');
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('can be used to assign focus', () => {
@@ -125,6 +126,7 @@ describe('useSetFocus', () => {
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeB']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(3);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('can be used to assign focus deeply by focusing a parent', () => {
@@ -191,6 +193,7 @@ describe('useSetFocus', () => {
     expect(focusState.focusedNodeId).toEqual('nodeB-A');
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeB', 'nodeB-A']);
     expect(focusState.activeNodeId).toEqual(null);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('ignores disabled nodes', () => {
@@ -244,6 +247,7 @@ describe('useSetFocus', () => {
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(3);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('it is a noop if the node does not exist', () => {
@@ -300,6 +304,7 @@ describe('useSetFocus', () => {
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(warning.mock.calls[0][1]).toEqual('NODE_DOES_NOT_EXIST');
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('it is a noop with a nonsense argument', () => {
@@ -356,5 +361,6 @@ describe('useSetFocus', () => {
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(warning.mock.calls[0][1]).toEqual('NODE_ID_NOT_STRING_TO_SET_FOCUS');
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/tests/disabled-nodes.test.js
+++ b/src/tests/disabled-nodes.test.js
@@ -64,6 +64,7 @@ describe('disabled FocusNodes', () => {
     ]);
 
     expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('does not warn when a focus tree mounts with a disabled child (gh-78)', () => {
@@ -77,5 +78,6 @@ describe('disabled FocusNodes', () => {
     );
 
     expect(console.error).toHaveBeenCalledTimes(0);
+    expect(warning).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/tests/focus-node-events.test.js
+++ b/src/tests/focus-node-events.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { FocusRoot, FocusNode, useFocusStoreDangerously } from '../index';
+import { warning } from '../utils/warning';
 
 describe('FocusNode Events', () => {
   describe('onMove', () => {
@@ -73,6 +74,9 @@ describe('FocusNode Events', () => {
           nextChildNode: focusStore.getState().nodes.nodeB,
         })
       );
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -133,6 +137,9 @@ describe('FocusNode Events', () => {
       expect(nodeAOnBlurred.mock.calls.length).toBe(1);
       expect(nodeBOnFocused.mock.calls.length).toBe(1);
       expect(nodeBOnBlurred.mock.calls.length).toBe(0);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -182,6 +189,9 @@ describe('FocusNode Events', () => {
       focusState = focusStore.getState();
       expect(focusState.focusedNodeId).toEqual('nodeA');
       expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('stopPropagation', () => {
@@ -223,6 +233,9 @@ describe('FocusNode Events', () => {
       focusState = focusStore.getState();
       expect(focusState.focusedNodeId).toEqual('nodeB');
       expect(focusState.focusHierarchy).toEqual(['root', 'nodeB']);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -295,6 +308,9 @@ describe('FocusNode Events', () => {
           targetNode: preFocusedNodeA,
         })
       );
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -362,6 +378,9 @@ describe('FocusNode Events', () => {
           targetNode: focusStore.getState().nodes.nodeA,
         })
       );
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/tests/focus-trap.test.js
+++ b/src/tests/focus-trap.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
 import {
   FocusRoot,
   FocusNode,
@@ -164,7 +164,7 @@ describe('Focus Traps', () => {
     );
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-A-A');
-    setFocus('nodeB');
+    act(() => setFocus('nodeB'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-A');
 
     fireEvent.keyDown(window, {
@@ -207,15 +207,14 @@ describe('Focus Traps', () => {
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-B');
 
-    setFocus('nodeA');
+    act(() => setFocus('nodeA'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-A-A');
 
-    setFocus('nodeB');
+    act(() => setFocus('nodeB'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-B');
 
     expect(warning).toHaveBeenCalledTimes(0);
-    // TODO: look into / fix these errors
-    // expect(console.error).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('supports forgetTrapFocusHierarchy', () => {
@@ -255,7 +254,7 @@ describe('Focus Traps', () => {
     );
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-A-A');
-    setFocus('nodeB');
+    act(() => setFocus('nodeB'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-A');
 
     fireEvent.keyDown(window, {
@@ -298,15 +297,14 @@ describe('Focus Traps', () => {
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-B');
 
-    setFocus('nodeA');
+    act(() => setFocus('nodeA'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-A-A');
 
-    setFocus('nodeB');
+    act(() => setFocus('nodeB'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-A');
 
     expect(warning).toHaveBeenCalledTimes(0);
-    // TODO: look into these errors
-    // expect(console.error).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('cannot be arrowed into when its deeply nested', () => {
@@ -397,7 +395,7 @@ describe('Focus Traps', () => {
     );
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-A-A');
-    setFocus('gridRoot');
+    act(() => setFocus('gridRoot'));
     expect(focusStore.getState().focusedNodeId).toEqual('gridItem1-1');
     expect(focusStore.getState().focusHierarchy).toEqual([
       'root',
@@ -437,10 +435,10 @@ describe('Focus Traps', () => {
 
     // We move focus out of the trap, and then back in, to ensure that the position
     // is retained
-    setFocus('nodeA');
+    act(() => setFocus('nodeA'));
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-A-A');
 
-    setFocus('gridRoot');
+    act(() => setFocus('gridRoot'));
     expect(focusStore.getState().focusedNodeId).toEqual('gridItem1-2');
     expect(focusStore.getState().focusHierarchy).toEqual([
       'root',
@@ -451,7 +449,6 @@ describe('Focus Traps', () => {
     ]);
 
     expect(warning).toHaveBeenCalledTimes(0);
-    // TODO: look into these
-    // expect(console.error).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/tests/focus-trap.test.js
+++ b/src/tests/focus-trap.test.js
@@ -29,6 +29,8 @@ describe('Focus Traps', () => {
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(warning.mock.calls[0][1]).toEqual('RESTORE_TRAP_FOCUS_WITHOUT_TRAP');
+
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('does not focus on mount', () => {
@@ -56,6 +58,9 @@ describe('Focus Traps', () => {
     );
 
     expect(focusStore.getState().focusedNodeId).toEqual('root');
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('cannot be arrowed into', () => {
@@ -121,6 +126,9 @@ describe('Focus Traps', () => {
     });
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-B');
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('can be focused and unfocused via useSetFocus', () => {
@@ -204,6 +212,10 @@ describe('Focus Traps', () => {
 
     setFocus('nodeB');
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-B');
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    // TODO: look into / fix these errors
+    // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('supports forgetTrapFocusHierarchy', () => {
@@ -291,6 +303,10 @@ describe('Focus Traps', () => {
 
     setFocus('nodeB');
     expect(focusStore.getState().focusedNodeId).toEqual('nodeB-A');
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    // TODO: look into these errors
+    // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('cannot be arrowed into when its deeply nested', () => {
@@ -339,6 +355,9 @@ describe('Focus Traps', () => {
     });
 
     expect(focusStore.getState().focusedNodeId).toEqual('nodeA-B');
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('behaves well with grids', () => {
@@ -430,5 +449,9 @@ describe('Focus Traps', () => {
       'gridRow1',
       'gridItem1-2',
     ]);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    // TODO: look into these
+    // expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/tests/grids.test.js
+++ b/src/tests/grids.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
 import {
   FocusRoot,
   useSetFocus,
@@ -540,7 +540,7 @@ describe('Grids', () => {
         'defaultFocus',
       ]);
 
-      setFocus('gridRoot');
+      act(() => setFocus('gridRoot'));
       expect(focusStore.getState().focusedNodeId).toEqual('gridItem1-1');
       expect(focusStore.getState().focusHierarchy).toEqual([
         'root',
@@ -551,8 +551,7 @@ describe('Grids', () => {
       ]);
 
       expect(warning).toHaveBeenCalledTimes(0);
-      // TODO: look into this
-      // expect(console.error).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('behaves as expected when focusing a grid row', () => {
@@ -593,7 +592,7 @@ describe('Grids', () => {
         'defaultFocus',
       ]);
 
-      setFocus('gridRow2');
+      act(() => setFocus('gridRow2'));
       expect(focusStore.getState().focusedNodeId).toEqual('gridItem2-1');
       expect(focusStore.getState().focusHierarchy).toEqual([
         'root',
@@ -604,8 +603,7 @@ describe('Grids', () => {
       ]);
 
       expect(warning).toHaveBeenCalledTimes(0);
-      // TODO: look into this
-      // expect(console.error).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('behaves as expected when focusing a grid item', () => {
@@ -646,7 +644,7 @@ describe('Grids', () => {
         'defaultFocus',
       ]);
 
-      setFocus('gridItem2-2');
+      act(() => setFocus('gridItem2-2'));
       expect(focusStore.getState().focusedNodeId).toEqual('gridItem2-2');
       expect(focusStore.getState().focusHierarchy).toEqual([
         'root',
@@ -657,8 +655,7 @@ describe('Grids', () => {
       ]);
 
       expect(warning).toHaveBeenCalledTimes(0);
-      // TODO: look into this
-      // expect(console.error).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/src/tests/grids.test.js
+++ b/src/tests/grids.test.js
@@ -33,6 +33,8 @@ describe('Grids', () => {
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(warning.mock.calls[0][1]).toEqual('ORIENTATION_ON_GRID');
+
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('warns when onGridMove is passed to a non-grid', () => {
@@ -54,6 +56,7 @@ describe('Grids', () => {
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(warning.mock.calls[0][1]).toEqual('GRID_MOVE_NOT_ON_GRID');
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('warns when onMove is passed', () => {
@@ -79,6 +82,7 @@ describe('Grids', () => {
 
     expect(warning).toHaveBeenCalledTimes(1);
     expect(warning.mock.calls[0][1]).toEqual('ON_MOVE_ON_GRID');
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   describe('1x1', () => {
@@ -119,6 +123,7 @@ describe('Grids', () => {
       expect(Object.values(focusState.nodes)).toHaveLength(4);
 
       expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -164,6 +169,7 @@ describe('Grids', () => {
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(8);
       expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('mounts correctly, respecting defaultColumnIndex/defaultRowIndex', () => {
@@ -212,6 +218,7 @@ describe('Grids', () => {
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(8);
       expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('navigates correctly (no wrapping)', () => {
@@ -332,6 +339,7 @@ describe('Grids', () => {
       ]);
       expect(focusState.activeNodeId).toEqual(null);
       expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('navigates correctly (wrapping horizontally)', () => {
@@ -411,6 +419,7 @@ describe('Grids', () => {
       ]);
       expect(focusState.activeNodeId).toEqual(null);
       expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('navigates correctly (wrapping vertically)', () => {
@@ -488,6 +497,7 @@ describe('Grids', () => {
       ]);
       expect(focusState.activeNodeId).toEqual(null);
       expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -541,6 +551,8 @@ describe('Grids', () => {
       ]);
 
       expect(warning).toHaveBeenCalledTimes(0);
+      // TODO: look into this
+      // expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('behaves as expected when focusing a grid row', () => {
@@ -592,6 +604,8 @@ describe('Grids', () => {
       ]);
 
       expect(warning).toHaveBeenCalledTimes(0);
+      // TODO: look into this
+      // expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('behaves as expected when focusing a grid item', () => {
@@ -643,6 +657,8 @@ describe('Grids', () => {
       ]);
 
       expect(warning).toHaveBeenCalledTimes(0);
+      // TODO: look into this
+      // expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -754,6 +770,8 @@ describe('Grids', () => {
       });
 
       expect(gridMove.mock.calls.length).toBe(2);
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/tests/mounting.test.js
+++ b/src/tests/mounting.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { FocusRoot, FocusNode, useFocusStoreDangerously } from '../index';
+import { warning } from '../utils/warning';
 
 //
 // These tests verify that the focus tree is accurate during the initial mount.
@@ -38,6 +39,9 @@ describe('Mounting', () => {
       expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(2);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -75,6 +79,9 @@ describe('Mounting', () => {
       expect(focusState.focusHierarchy).toEqual(['root']);
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(3);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('does not leap over disabled parent nodes', () => {
@@ -116,6 +123,9 @@ describe('Mounting', () => {
       expect(focusState.focusHierarchy).toEqual(['root']);
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(4);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('automatically assigns focus to the first node', () => {
@@ -155,6 +165,9 @@ describe('Mounting', () => {
       expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(3);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('does not move focus when arrows other than right are pressed', () => {
@@ -261,6 +274,9 @@ describe('Mounting', () => {
       });
 
       expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -328,6 +344,9 @@ describe('Mounting', () => {
       ]);
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(7);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
 
     it('handles `onMountAssignFocusTo`', () => {
@@ -398,6 +417,9 @@ describe('Mounting', () => {
       ]);
       expect(focusState.activeNodeId).toEqual(null);
       expect(Object.values(focusState.nodes)).toHaveLength(9);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/tests/pointer-events.test.js
+++ b/src/tests/pointer-events.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, fireEvent, createEvent, screen } from '@testing-library/react';
 import { FocusRoot, FocusNode, useFocusStoreDangerously } from '../index';
+import { warning } from '../utils/warning';
 
 describe('Pointer Events', () => {
   it('has them disabled by default', () => {
@@ -34,6 +35,9 @@ describe('Pointer Events', () => {
     focusState = focusStore.getState();
     expect(focusState.focusedNodeId).toEqual('nodeA');
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('can be enabled, and can move focus on mouse move when the interaction mode is pointer', (done) => {
@@ -82,6 +86,9 @@ describe('Pointer Events', () => {
 
       expect(nodeBOnClick.mock.calls.length).toBe(1);
 
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
+
       done();
     });
   });
@@ -129,6 +136,9 @@ describe('Pointer Events', () => {
       fireEvent(nodeB, clickEvent);
 
       expect(nodeBOnClick.mock.calls.length).toBe(0);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
 
       done();
     });
@@ -183,6 +193,9 @@ describe('Pointer Events', () => {
 
       expect(nodeOnSelected.mock.calls.length).toBe(0);
       expect(nodeOnClick.mock.calls.length).toBe(1);
+
+      expect(warning).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
 
       done();
     });

--- a/src/tests/tree-updates.test.js
+++ b/src/tests/tree-updates.test.js
@@ -88,7 +88,7 @@ describe('Tree updates', () => {
     expect(Object.values(focusState.nodes)).toHaveLength(3);
 
     expect(warning).toHaveBeenCalledTimes(0);
-    // TODO: look into this
+    // TODO: see gh-92
     // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
@@ -134,7 +134,7 @@ describe('Tree updates', () => {
     expect(Object.values(focusState.nodes)).toHaveLength(4);
 
     expect(warning).toHaveBeenCalledTimes(0);
-    // TODO: look into this
+    // TODO: see gh-92
     // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
@@ -175,7 +175,7 @@ describe('Tree updates', () => {
     expect(Object.values(focusState.nodes)).toHaveLength(3);
 
     expect(warning).toHaveBeenCalledTimes(0);
-    // TODO: look into this
+    // TODO: see gh-92
     // expect(console.error).toHaveBeenCalledTimes(0);
   });
 

--- a/src/tests/tree-updates.test.js
+++ b/src/tests/tree-updates.test.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import '@testing-library/jest-dom';
 import { render, act, screen } from '@testing-library/react';
 import { FocusRoot, FocusNode, useFocusStoreDangerously } from '../index';
+import { warning } from '../utils/warning';
 
 //
 // React Apps frequently mount and unmount components as a user interacts
@@ -45,6 +46,9 @@ describe('Tree updates', () => {
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeA', 'nodeA-A']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(3);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('disabled (leaf node child)', () => {
@@ -82,6 +86,10 @@ describe('Tree updates', () => {
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(3);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    // TODO: look into this
+    // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   // TODO: update this behavior! See gh-55
@@ -124,6 +132,10 @@ describe('Tree updates', () => {
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(4);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    // TODO: look into this
+    // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('focus trap child', () => {
@@ -161,6 +173,10 @@ describe('Tree updates', () => {
     expect(focusState.focusHierarchy).toEqual(['root', 'nodeA']);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(3);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    // TODO: look into this
+    // expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('moves focus to a new child node that is mounted (two levels)', () => {
@@ -207,6 +223,9 @@ describe('Tree updates', () => {
     ]);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(4);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('respects `onMountAssignFocusTo`', () => {
@@ -254,6 +273,9 @@ describe('Tree updates', () => {
     ]);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(5);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('works with grids', () => {
@@ -313,5 +335,8 @@ describe('Tree updates', () => {
     ]);
     expect(focusState.activeNodeId).toEqual(null);
     expect(Object.values(focusState.nodes)).toHaveLength(9);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/utils/warning.test.js
+++ b/src/utils/warning.test.js
@@ -21,4 +21,13 @@ describe('warning', () => {
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error.mock.calls[0][0]).toEqual('uh oh');
   });
+
+  it('supports multiple calls by omitting a key', () => {
+    warning('uh oh1');
+    warning('uh oh2');
+
+    expect(console.error).toHaveBeenCalledTimes(2);
+    expect(console.error.mock.calls[0][0]).toEqual('uh oh1');
+    expect(console.error.mock.calls[1][0]).toEqual('uh oh2');
+  });
 });

--- a/src/utils/warning.ts
+++ b/src/utils/warning.ts
@@ -4,7 +4,7 @@ interface CodeCache {
 
 let codeCache: CodeCache = {};
 
-export function warning(message: string, code: string) {
+export function warning(message: string, code?: string) {
   // This ensures that each warning type is only logged out one time
   if (code) {
     if (codeCache[code]) {


### PR DESCRIPTION
Resolves #90 

### Todo

- [x] Go through each test that is logging errors when there aren't errors and figure out what's going on
- [x] Add remaining tests

---

Heads up to @LBRDan ...there are currently 11 tests where `enforce-state-structure` logs are being logged...there's a good chance many of them are false positives, just like the issue you opened (#78 ). Just wanted to give you a heads up in case you see any other issues...I'm lookin' into it though 👀 

----

There are 9 situations where this is unexpected.

`tree-updates.test.js`
3 errors. Related issue: #92 

`focus-trap.test.js`
3 errors. Forgot to wrap state-changing fn calls in `act()`

`grids.test.js`
3 errors. same as above