### PR TITLE
Freeze all focus updates

### DIFF
--- a/src/focus-store.ts
+++ b/src/focus-store.ts
@@ -160,6 +160,9 @@ export default function createFocusStore({
         );
 
         let updatedFocusState = possibleNewState;
+
+        // TODO: look at this condition. I may need to always update the focus here
+        // now
         if (focusedItemIndex > -1 || assigningFocusOnMount > -1) {
           updatedFocusState = updateFocus({
             focusState: possibleNewState,

--- a/src/tests/mounting.test.js
+++ b/src/tests/mounting.test.js
@@ -424,7 +424,7 @@ describe('Mounting', () => {
   });
 
   // TODO: test number and function
-  it('respects `defaultFocusChild` at mount', () => {
+  it.only('respects `defaultFocusChild` at mount (gh-70)', () => {
     let focusStore;
 
     function TestComponent() {

--- a/src/tests/mounting.test.js
+++ b/src/tests/mounting.test.js
@@ -422,4 +422,35 @@ describe('Mounting', () => {
       expect(console.error).toHaveBeenCalledTimes(0);
     });
   });
+
+  // TODO: test number and function
+  it('respects `defaultFocusChild` at mount', () => {
+    let focusStore;
+
+    function TestComponent() {
+      focusStore = useFocusStoreDangerously();
+
+      return (
+        <FocusNode focusId="nodeRoot" defaultFocusChild={1}>
+          <FocusNode focusId="nodeA" data-testid="nodeA"></FocusNode>
+          <FocusNode focusId="nodeB" data-testid="nodeB"></FocusNode>
+        </FocusNode>
+      );
+    }
+
+    render(
+      <FocusRoot>
+        <TestComponent />
+      </FocusRoot>
+    );
+
+    const focusState = focusStore.getState();
+    expect(focusState.focusedNodeId).toEqual('nodeB');
+    expect(focusState.focusHierarchy).toEqual(['root', 'nodeRoot', 'nodeB']);
+    expect(focusState.activeNodeId).toEqual(null);
+    expect(Object.values(focusState.nodes)).toHaveLength(7);
+
+    expect(warning).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/utils/create-node.ts
+++ b/src/utils/create-node.ts
@@ -46,15 +46,16 @@ export default function createNodeDefinitionHierarchy({
       }
 
       onMountAssignFocusTo = nodeDefinition.onMountAssignFocusTo;
+    }
 
-      // We only actually assign the focus when this thing happens
-      if (isLastNode) {
-        // We disable the focus lock whenever we "apply" an `onMountAssignFocusTo`
-        shouldLockFocus = false;
+    if (isLastNode) {
+      shouldLockFocus = false;
+
+      if (nodeDefinition.onMountAssignFocusTo !== undefined) {
         onMountAssignFocusToReturn = nodeDefinition.onMountAssignFocusTo;
-      } else {
-        shouldLockFocus = true;
       }
+    } else {
+      shouldLockFocus = false;
     }
 
     if (


### PR DESCRIPTION
See #70 

For more context see the comments over #70 

---

Todo:

- [ ] Consider if all create events should freeze the tree
- [ ] Make any necessary changes
- [ ] Add a guide explaining the difference between `onMountAssignFocusTo` and `defaultFocusChild`