### PR TITLE
feature: Exposing to default export common useful types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,11 @@ export { default as useProcessKey } from './hooks/use-process-key';
 
 const FocusRoot = FocusContext.FocusRoot;
 export { FocusRoot };
+
+export type {
+  LRUDEvent,
+  FocusEvent,
+  MoveEvent,
+  GridMoveEvent,
+  FocusNodeProps,
+} from './types';


### PR DESCRIPTION
This PR adds some externally exposed types that may be useful using the library

Eg: FocusNodeProps['onSelected'] when using `useCallback<T>`