### PR TITLE
Add types for framer-motion

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://github.com/jamesplease/lrud#readme",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "framer-motion": "^6.2.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "5.14.1",

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -22,6 +22,7 @@ import {
   ProviderValue,
   ReactNodeRef,
 } from './types';
+import { MotionProps } from 'framer-motion';
 
 let uniqueId = 0;
 
@@ -96,7 +97,7 @@ export function FocusNode(
 
     ...otherProps
   }: FocusNodeProps,
-  ref: ReactNodeRef
+  ref: ReactNodeRef,
 ) {
   const elRef = useRef(null);
 
@@ -550,5 +551,5 @@ export function FocusNode(
   );
 }
 
-const ForwardedFocusNode = forwardRef(FocusNode);
+const ForwardedFocusNode = forwardRef<FocusNodeProps & HTMLElement &  MotionProps>(FocusNode);
 export default ForwardedFocusNode;

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -551,5 +551,5 @@ export function FocusNode(
   );
 }
 
-const ForwardedFocusNode = forwardRef<FocusNodeProps & HTMLElement &  MotionProps>(FocusNode);
+const ForwardedFocusNode = forwardRef<HTMLElement, FocusNodeProps & MotionProps>(FocusNode);
 export default ForwardedFocusNode;

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -97,7 +97,7 @@ export function FocusNode(
 
     ...otherProps
   }: FocusNodeProps,
-  ref: ReactNodeRef,
+  ref: ReactNodeRef
 ) {
   const elRef = useRef(null);
 


### PR DESCRIPTION
Adds support for framer motion props.

Example error:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/1948935/161675159-4f6a6efa-1798-43ac-8751-c51da56b502e.png">
`
Property 'initial' does not exist on type 'IntrinsicAttributes & FocusNodeProps & RefAttributes<HTMLElement>
`
&nbsp;

Focus-node.d.ts snippet (before fix)
```
declare const ForwardedFocusNode: React.ForwardRefExoticComponent<FocusNodeProps & React.RefAttributes<HTMLElement>>;
```

Focus-node.d.ts snippet(after fix)
```
declare const ForwardedFocusNode: React.ForwardRefExoticComponent<FocusNodeProps & MotionProps & React.RefAttributes<HTMLElement>>;
```

---
The downside of this PR is that non-motion FocusNodes will accept the motion properties without triggering a typescript build error. Feel free to close if this is a deal breaker.

styled-components has an implementation `as` which functions similarly to `elementType` and adds types correctly, but I haven't yet had time to dig into how it works and to implement it.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/styled-components/index.d.ts#L97
