### PR TITLE
feat: add onNoNavigation event to track arrow keypresses that did not result in movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ All props are optional. Example usage appears beneath the props table.
 | `onSelected`                | function            |                  | A function that is called when the user pressed the select button. Passed one argument, an [LRUDEvent](#lrudevent).                                                                    |
 | `onBack`                    | function            |                  | A function that is called when the user presses the back button. Passed one argument, an [LRUDEvent](#lrudevent).                                                                      |
 | `onMove`                    | function            |                  | A function that is called when the focused child index of this node changes. Only called for nodes with children that are _not_ grids. Passed one argument, a [MoveEvent](#moveevent). |
+| `onNoNavigation`            | function            |                  | A function that is called when the an arrow was pressed but nothing changed. Passed one argument, a [NoMoveEvent](#nomoveevent). |
 | `onGridMove`                | function            |                  | A function that is called when the focused child index of this node changes. Only called for grids. Passed one argument, a [GridMoveEvent](#gridmoveevent).                            |
 | `children`                  | React Node(s)       |                  | Children of the Focus Node.                                                                                                                                                            |
 | `...rest`                   | any                 |                  | All other props are applied to the underlying DOM node.                                                                                                                                |
@@ -450,6 +451,18 @@ An object that is passed to you in the `onMove` callback of a [`FocusNode` compo
 | `nextChildIndex` | number                            | The index of the child [`FocusNode`](#focusnode) that is now focused.        |
 | `prevChildNode`  | [FocusNode](#focusnode) \| `null` | The previously-focused [`FocusNode`](#focusnode).                            |
 | `nextChildNode`  | [FocusNode](#focusnode)           | The child [`FocusNode`](#focusnode) that is now focused.                     |
+
+### `NoMoveEvent`
+
+An object that is passed to you in the `onNoNavigation` callback of a [`FocusNode` component](#FocusNode-).
+
+| Property         | Type                              | Description                                                                  |
+| ---------------- | --------------------------------- | ---------------------------------------------------------------------------- |
+| `orientation`    | string                            | The orientation of the move. Either `"horizontal"` or `"vertical"`.          |
+| `direction`      | string                            | The direction of the move. Either `"forward"` or `"back"`.                   |
+| `arrow`          | string                            | The arrow that was pressed. One of `"up"`, `"down"`, `"left"`, or `"right"`. |
+| `node`           | [FocusNode](#focusnode) \| `null` | The [`FocusNode`](#focusnode) that received a key press, but no movement happened |
+
 
 ### `GridMoveEvent`
 

--- a/src/focus-node.tsx
+++ b/src/focus-node.tsx
@@ -86,6 +86,7 @@ export function FocusNode(
     onBack,
 
     onMove,
+    onNoNavigation,
     onGridMove,
 
     onFocused,
@@ -118,6 +119,7 @@ export function FocusNode(
     onBack,
 
     onMove,
+    onNoNavigation,
     onGridMove,
 
     onFocused,
@@ -139,6 +141,7 @@ export function FocusNode(
       onBack,
 
       onMove,
+      onNoNavigation,
       onGridMove,
 
       onFocused,
@@ -158,6 +161,7 @@ export function FocusNode(
     onBack,
 
     onMove,
+    onNoNavigation,
     onGridMove,
 
     onFocused,
@@ -271,6 +275,7 @@ export function FocusNode(
       onBack: createCallbackWrapper('onBack'),
 
       onMove: createCallbackWrapper('onMove'),
+      onNoNavigation: createCallbackWrapper('onNoNavigation'),
       onGridMove: createCallbackWrapper('onGridMove'),
 
       initiallyDisabled: Boolean(disabled),

--- a/src/handle-arrow/default-no-navigation/default-no-navigation.ts
+++ b/src/handle-arrow/default-no-navigation/default-no-navigation.ts
@@ -1,0 +1,25 @@
+import { Node, Orientation, Direction, Arrow } from '../../types';
+
+interface DefaultNoNavigationOptions {
+  orientation: Orientation;
+  direction: Direction;
+  focusedNode: Node;
+  arrow: Arrow;
+}
+
+export function defaultNoNavigation({
+  orientation,
+  direction,
+  focusedNode,
+  arrow,
+}: DefaultNoNavigationOptions) {
+  if (focusedNode.onNoNavigation) {
+    focusedNode.onNoNavigation({
+      orientation,
+      direction,
+      node: focusedNode,
+      arrow,
+    });
+  }
+  return null;
+}

--- a/src/handle-arrow/handle-arrow.ts
+++ b/src/handle-arrow/handle-arrow.ts
@@ -2,6 +2,7 @@ import defaultNavigation from './default-navigation/default-navigation';
 import gridNavigation from './grid-navigation/grid-navigation';
 import determineNavigationStyle from './determine-navigation-style/determine-navigation-style';
 import { FocusState, Arrow, Orientation, Direction } from '../types';
+import { defaultNoNavigation } from './default-no-navigation/default-no-navigation';
 
 interface HandleArrowOptions {
   focusState: FocusState;
@@ -32,7 +33,12 @@ export default function handleArrow({
   });
 
   if (!navigationStyle) {
-    return null;
+    return defaultNoNavigation({
+      arrow,
+      focusedNode,
+      direction,
+      orientation,
+    });
   } else if (navigationStyle.style === 'default') {
     return defaultNavigation({
       arrow,

--- a/src/tests/focus-node-events.test.tsx
+++ b/src/tests/focus-node-events.test.tsx
@@ -6,6 +6,72 @@ import { FocusRoot, FocusNode, useFocusStoreDangerously } from '../index';
 import { warning } from '../utils/warning';
 
 describe('FocusNode Events', () => {
+  describe('onNoNavigation', () => {
+    it('calls it when no movement occurs', () => {
+      const rootOnNoNavigation = jest.fn();
+      const nodeANoNavigation = jest.fn();
+      const nodeBNoNavigation = jest.fn();
+      let focusStore;
+
+      function TestComponent() {
+        focusStore = useFocusStoreDangerously();
+
+        return (
+          <FocusNode onNoNavigation={rootOnNoNavigation}>
+            <FocusNode
+              focusId="nodeA"
+              onNoNavigation={nodeANoNavigation}
+              data-testid="nodeA"
+            />
+            <FocusNode
+              focusId="nodeB"
+              data-testid="nodeB"
+              onNoNavigation={nodeBNoNavigation}
+            />
+          </FocusNode>
+        );
+      }
+
+      render(
+        <FocusRoot>
+          <TestComponent />
+        </FocusRoot>
+      );
+
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeA');
+
+      // No movement, so onNoNavigation fires
+      fireEvent.keyDown(window, {
+        code: 'ArrowLeft',
+        key: 'ArrowLeft',
+      });
+      expect(rootOnNoNavigation.mock.calls.length).toBe(0);
+      expect(nodeANoNavigation.mock.calls.length).toBe(1);
+      expect(nodeBNoNavigation.mock.calls.length).toBe(0);
+
+      // move to the right, there is movement
+      fireEvent.keyDown(window, {
+        code: 'ArrowRight',
+        key: 'ArrowRight',
+      });
+
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeB');
+
+      expect(rootOnNoNavigation.mock.calls.length).toBe(0);
+      expect(nodeANoNavigation.mock.calls.length).toBe(1);
+      expect(nodeBNoNavigation.mock.calls.length).toBe(0);
+
+      fireEvent.keyDown(window, {
+        code: 'ArrowRight',
+        key: 'ArrowRight',
+      });
+
+      expect(rootOnNoNavigation.mock.calls.length).toBe(0);
+      expect(nodeANoNavigation.mock.calls.length).toBe(1);
+      expect(nodeBNoNavigation.mock.calls.length).toBe(1);
+    });
+  });
+
   describe('onMove', () => {
     it('calls it when movement occurs', () => {
       const rootOnMove = jest.fn();

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,13 @@ export interface MoveEvent {
   nextChildNode: Node;
 }
 
+export interface NoMoveEvent {
+  orientation: Orientation;
+  direction: Direction;
+  arrow: Arrow;
+  node: Node;
+}
+
 export interface GridMoveEvent {
   orientation: Orientation;
   direction: Direction;
@@ -81,6 +88,7 @@ export interface LRUDFocusEvents {
 }
 
 export interface FocusNodeEvents extends LRUDFocusEvents {
+  onNoNavigation?: (e: NoMoveEvent) => void;
   onMove?: (e: MoveEvent) => void;
   onGridMove?: (e: GridMoveEvent) => void;
 

--- a/src/utils/node-from-definition.ts
+++ b/src/utils/node-from-definition.ts
@@ -28,6 +28,7 @@ export default function nodeFromDefinition({
 
     onMove,
     onGridMove,
+    onNoNavigation,
   } = nodeDefinition;
 
   const parentId = parentNode.focusId;
@@ -96,6 +97,7 @@ export default function nodeFromDefinition({
     onBlurred,
 
     onMove,
+    onNoNavigation,
     onGridMove,
   };
 


### PR DESCRIPTION
## Purpose

This adds a new prop called `onNoNavigation` to `<FocusNode />` which allows developers to tap into if they want to know if there was no change in LRUD focus when an arrow key was pressed.

Such examples where this method could be useful:
1. Triggering an action due to no movement but want to know key was pressed (e.g. want to know left was pressed to do something as long the focus has not moved)
2. Creating an audible / visual indicator for the focused node that they've reached the end

## Changes

1. feat(focus-node): New prop - `onNoNavigation` -  to track when an arrow was pressed on the focused node but there was no movement.
2. feat(NoMoveEvent): NoMoveEvent({arrow, orientation, node, direction}) - useful to know what was the arrow/orientation/direction that caused no movement, so we can act accordingly


## Considerations thought about
1. Is it possible to do track if a keypress occurred but it resulted in no movement w/o this `onNoNavigation` callback? 

I imagine it could be something like having a component listen on keypress of the arrow keys, and using `useLeafFocusedNode` and another state to keep track. ~~Not sure if it might need 2 keypresses though, because it depends on how the state is managed - if it's via `useState` it will.~~

2. Are there any alternatives?

**Idea 2 - Using `useLeafFocusedNode`, keydown listeners and relying on the fact that the leaf focused node changes causes react to re-render and unsubscribe**

Turns out, since `useLeafFocusedNode` changes if a keydown does cause movement, it will cause the keydown event listener in `useEffect` to subscribe and unsubscribe due to the re-render, thus doing no-op. If there is no change due to a keydown not causing movement, then it the keypress event will do an operation since it did not re-render. This idea may look better: https://github.com/hrgui/lrud/commit/2f9debabf33cd7a946db1e84d41a97315cc0f04b. 

**Idea 3 - Using `useFocusStoreDangerously` and monkey-patching handleArrow**

I found relying on react nuances isn't a good idea, as it isn't so testable. I did realized `focusStore` does expose the handleArrow, in which we can patch, which should help me in my case where I need to detect boundaries.

https://github.com/hrgui/lrud/commit/0a761fee9af586bafb45a995896a511c2998e355

The idea is if the state changes after handleArrow, then we didn't hit a boundary. If the state stayed the same, we hit a boundary.

Here is the improved version, that allows callbacks to change, which uses a subscriber system:

https://github.com/hrgui/lrud/commit/5e0535b273403b8dd60f686bb4c88d94b98b6a81

3. How should we inform the parent FocusNode that nothing happened? For `onMove`, the immediate parent knows something happened. Not sure if we can easily do that for `onNoNavigation`.





