### PR TITLE
Fix focus navigation while fetching nested nodes

### DIFF
--- a/src/focus-store.ts
+++ b/src/focus-store.ts
@@ -389,12 +389,17 @@ export default function createFocusStore({
   }
 
   function handleArrow(arrow: Arrow) {
-    const newState = handleArrowUtil({
+    const { newState, prevState } = handleArrowUtil({
       focusState: currentState,
       arrow,
-    });
+    }) || {};
 
     if (!newState) {
+      return;
+    }
+
+    if (prevState !== currentState) {
+      handleArrow(arrow);
       return;
     }
 

--- a/src/handle-arrow/handle-arrow.ts
+++ b/src/handle-arrow/handle-arrow.ts
@@ -8,10 +8,15 @@ interface HandleArrowOptions {
   arrow: Arrow;
 }
 
+type HandleArrowResult = {
+  prevState: FocusState;
+  newState: FocusState | null;
+} | null;
+
 export default function handleArrow({
   focusState,
   arrow,
-}: HandleArrowOptions): FocusState | null {
+}: HandleArrowOptions): HandleArrowResult {
   const orientation: Orientation =
     arrow === 'right' || arrow === 'left' ? 'horizontal' : 'vertical';
   const direction: Direction =
@@ -34,15 +39,17 @@ export default function handleArrow({
   if (!navigationStyle) {
     return null;
   } else if (navigationStyle.style === 'default') {
-    return defaultNavigation({
+    const newState = defaultNavigation({
       arrow,
       focusState,
       targetNode: navigationStyle.targetNode,
       direction,
       orientation,
     });
+
+    return { prevState: focusState, newState };
   } else if (navigationStyle.style === 'grid') {
-    return gridNavigation({
+    const newState = gridNavigation({
       arrow,
       focusState,
       focusedNode,
@@ -51,6 +58,8 @@ export default function handleArrow({
       direction,
       orientation,
     });
+
+    return { prevState: focusState, newState };
   }
 
   return null;


### PR DESCRIPTION
When navigating through parent nodes while fetching nested child nodes, lrud loses focus of the fetched child nodes. This occurs because, upon pressing the button, lrud triggers the handleArrow function. During the processing of parentNode.onMove or gridNode.onGridMove, lrud adds the child nodes to the store. However, after completing these actions, lrud updates the current store to a new one, based on the old store but without incorporating the child nodes.